### PR TITLE
Magic getter now returns null if property is not set. Fixes #20

### DIFF
--- a/traits/magic_methods.php
+++ b/traits/magic_methods.php
@@ -39,9 +39,13 @@ trait Magic_Methods
 	 */
 	final public function __get($prop)
 	{
-		return (is_array($this->{$this::MAGIC_PROPERTY}))
-			? $this->{$this::MAGIC_PROPERTY}[$prop]
-			: $this->{$this::MAGIC_PROPERTY}->$prop;
+		if ($this->__isset($prop)) {
+			return (is_array($this->{$this::MAGIC_PROPERTY}))
+				? $this->{$this::MAGIC_PROPERTY}[$prop]
+				: $this->{$this::MAGIC_PROPERTY}->$prop;
+		} else {
+			return null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Do an `isset()` before getting.
